### PR TITLE
linking between onboarding docs

### DIFF
--- a/docs/encrypting_secrets.md
+++ b/docs/encrypting_secrets.md
@@ -69,3 +69,7 @@ env:
     ciphertext: 3A6IWdP4fZoiI+xjENaxGI3MSue6svKk5l3ecXCJt4+sbD5X9M2IcvN6sBooi9jjKyQf55ojhzSlC2Wzaaw/d4Y1Ulh2kH4lae1UHrpT+K5yvah3PqZ51xU+TZqV4+7pd2YGpoEpdNsw3C/ZfLg+tt2JjpK0nOXnbgVTLrcqqVQj7PpjNSXFXr2IJmULgybRgCBKmBoTJWcLasLVvhuTOqdU5ZCm0fp/RXRltlK3/pFE1YMOXrVOGbozNluoHS5b5JrdOGZuHZ+He56PmH3bh4d1pWmi970gI+BQ3GBkyLOxdYigK0d/z8mZCdsc0G93GRS35J3HSg2cHoACsXPvCxAFSwt73skBsNMKuRdplrBc0YSpld5lG9ccTISGKf1t0YtXlDYI5bT/jZH56DcU0Lyz54zBo+PjNEQN4nGOil3d/pjBSXi0UuDH3GWEIw7Tvb08N3GfYPMQd5rPVagVyQjrHwGBugMDQy1SEtlsTBXl76porBnurAcb0LCiGQv+Q1dJCMG+JM1PE+qLrj6cOANhDWj8lCsHD7Nyz5Q4wJehnznvHKobDwZ50bEde53grXCp5s4gLOmaG9JCa8pDUjlM7ppqEkZcERFjKfp2VVicJI9Skcd1NRB9yemJrtdUKlsD5OOawZER0piJCBfQewJmBBDvtU7K5lPSUWqshH8=
     scheme: RSAES_OAEP_SHA_256
 ```
+
+### Reserved Variables
+
+See the [reserved variables](https://github.com/meltano/cloud-docs/blob/main/docs/reserved_variables.md) docs for more details on variables that are reserved for use by Meltano Cloud.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -71,15 +71,9 @@ To onboard your project, Meltano will need the following project information:
 After receiving the above information, Meltano will register your project(s) and generate a new set of encryption and decryption keys specific to your organization. We will then provide you with your organization's public key along with instructions to encrypt your `.env` file and attach your encrypted file to your project.
 
 The [kms-ext tool](https://github.com/meltano/kms-ext) is available to use for the encryption process.
+See the [encrypting secrets docs](encrypting_secrets.md) for more details and examples of how to do this.
 
-Ex:
-```
-pip install pipx
-pipx install git+https://github.com/meltano/kms-ext.git@main
-kms encrypt <pubkey_file_path> --dotenv-path <env_file_path> --output-path <secrets.yml_path>
-```
-
-See the [security whitepaper](security.md) for more information on encryption algorithms.
+Also see the [security whitepaper](security.md) for more information on encryption algorithms.
 
 ### Step 3: Initial execution and debugging
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -72,6 +72,7 @@ After receiving the above information, Meltano will register your project(s) and
 
 The [kms-ext tool](https://github.com/meltano/kms-ext) is available to use for the encryption process.
 See the [encrypting secrets docs](encrypting_secrets.md) for more details and examples of how to do this.
+Also be aware that there are some [reserved variables](https://github.com/meltano/cloud-docs/blob/main/docs/reserved_variables.md) only for use by Meltano Cloud.
 
 Also see the [security whitepaper](security.md) for more information on encryption algorithms.
 


### PR DESCRIPTION
@magreenbaum it took me a second to find the new docs for encrypting secrets so I'm proposing that we link out to the detailed docs from the main onboarding doc. Just a suggestion though so feel free to adjust or disregard 😄 .